### PR TITLE
Missing lein-midje plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [org.clojure/test.check "0.10.0-alpha3"]
                  [quil "2.7.1"]
                  [org.clojure/math.combinatorics "0.1.4"]]
-  :profiles {:dev {:dependencies [[midje "1.9.2"]]}
+  :profiles {:dev {:dependencies [[midje "1.9.2"]]
+                   :plugins [[lein-midje "3.2.1"]]}
              ;; You can add dependencies that apply to `lein midje` below.
              ;; An example would be changing the logging destination for test runs.
              ;; Note that Midje itself is in the `dev` profile to support


### PR DESCRIPTION
`lein-midje` plugin is necessary to run the tests. The plugin dependency is missing in project.clj.